### PR TITLE
Link to Implementing instead of ATAG spec (fixes #25)

### DIFF
--- a/src/components/SuccessCriterion.svelte
+++ b/src/components/SuccessCriterion.svelte
@@ -20,7 +20,7 @@
   let notes = null;
   let list = null;
   const normalisedCriterionId = num.replace(/\./g, '').toLowerCase();
-  const linkToCriterion = `https://www.w3.org/TR/ATAG20/#sc_${normalisedCriterionId}`;
+  const linkToImplementing = `https://www.w3.org/WAI/AU/2012/WD-IMPLEMENTING-ATAG20-20121011/#sc_${normalisedCriterionId}`;
 
   $: notes = details ? details.filter(detail => detail.type === 'note') : null;
   $: list = details ? details.filter(detail => detail.type === 'olist' || detail.type === 'ulist') : null;
@@ -29,7 +29,7 @@
 <div {id}>
   <h4>
     {handle}
-    <a href={linkToCriterion} class="criterion__ref" target="_blank"><abbr title="Success Criterion">SC</abbr> {num}</a>
+    <a href={linkToImplementing} class="criterion__ref" target="_blank">Implementing {num}</a>
     <MoreInfo label="Info about {num}">
       <p>Provide plain text alternatives when using icons, images and other non-text content. For instance, if you have a button that is just an icon, make sure there is a label associated.</p>
     </MoreInfo> 


### PR DESCRIPTION
I'm addressing this by:

* replacing the “SC X.Y.Z” with “Implementing X.Y.Z.”
* removing “SC” because I think the number alone is clear enough, given it is next to the SC's official handle
* showing number instead of “How to implement” so that we have unique, descriptive links and the number is still displayed 

Before: 

<img width="460" alt="Heading content changes reversible, tag-like link with text SC A.4.1.1" src="https://user-images.githubusercontent.com/178782/74219208-7937b000-4cac-11ea-979b-35635c16f77e.png">

After:

<img width="560" alt="Heading content changes reversible, tag-like link with text Implementing A.4.1.1" src="https://user-images.githubusercontent.com/178782/74219253-9c625f80-4cac-11ea-8b1f-fbb31fe80237.png">

