### PR TITLE
Add conformance target

### DIFF
--- a/src/components/EvaluationInfo.svelte
+++ b/src/components/EvaluationInfo.svelte
@@ -28,6 +28,8 @@
   });
 
   $: evaluatedItems = getEvaluatedItems($evaluation);
+  $: totalCriteria = Object.values($evaluation.evaluationData).filter( item => item.level.length <= $evaluation.meta.conformanceTarget.value.length).length;
+
 </script>
 
 <aside>
@@ -57,7 +59,7 @@
       {/if}
     </h2>
     {#if evaluatedItems && $evaluation.evaluationData}
-    <p>Reported on <strong>{evaluatedItems.length}</strong> out of <strong>{Object.values($evaluation.evaluationData).length}</strong> success criteria.</p>
+    <p>Reported on <strong>{evaluatedItems.length}</strong> out of <strong>{totalCriteria}</strong> success criteria.</p>
     {/if}
     <button class="button" on:click={toOverview}>View report</button>
     <button class="button button-secondary" on:click={clear}>Clear</button>

--- a/src/components/LinkToSC.svelte
+++ b/src/components/LinkToSC.svelte
@@ -1,0 +1,23 @@
+<script>
+  export let href;
+</script>
+
+<a {href} class="link-to-sc" target="_blank"><slot></slot></a>
+
+<style>
+.link-to-sc {
+  padding: .25em 1em;
+  border-radius: 1em;
+  margin-left: .75em;
+  background-color: var(--cloudy-subtle);
+  border: 1px solid var(--cloudy-subtle);
+  font-size: 70%;
+  color: inherit;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.link-to-sc:hover {
+  background-color: transparent;
+  border-color: var(--ocean);
+}
+</style>

--- a/src/components/SuccessCriterion.svelte
+++ b/src/components/SuccessCriterion.svelte
@@ -21,11 +21,11 @@
   $: linkToImplementing = `https://www.w3.org/WAI/AU/2012/WD-IMPLEMENTING-ATAG20-20121011/#sc_${normalisedCriterionId}`;
   $: notes = details ? details.filter(detail => detail.type === 'note') : null;
   $: list = details ? details.filter(detail => detail.type === 'olist' || detail.type === 'ulist') : null;
-  $: inConformanceTarget = $evaluation.meta.conformanceTarget.value.length >= level.substring(6).length;
+  $: inConformanceTarget = $evaluation.meta.conformanceTarget.value.length >= level.length;
 </script>
 
 <div id={normalisedCriterionId} class="criterion">
-  {#if inConformanceTarget || level === "Level A, AA, AAA"}
+  {#if inConformanceTarget || level === "A, AA, AAA"}
     <SuccessCriterionHeader {num} {handle} {level} />
     <p>{text}</p>
     {#if list}<SuccessCriterionDetails type="list" details={list} />{/if}

--- a/src/components/SuccessCriterion.svelte
+++ b/src/components/SuccessCriterion.svelte
@@ -4,13 +4,14 @@
   import EvaluationResultSelector from './EvaluationResultSelector.svelte';
   import EvaluationObservation from './EvaluationObservation.svelte';
   import SuccessCriterionDetails from './SuccessCriterionDetails.svelte';
+  import SuccessCriterionHeader from './SuccessCriterionHeader.svelte';
   import { normaliseCriterionId } from '../utils/normaliseCriterionId';
 
   export let id;
   export let num;
   export let handle;
   export let text;
-  export let level = 'A';
+  export let level = null;
   export let details = null;
 
   let notes = null;
@@ -20,20 +21,33 @@
   $: linkToImplementing = `https://www.w3.org/WAI/AU/2012/WD-IMPLEMENTING-ATAG20-20121011/#sc_${normalisedCriterionId}`;
   $: notes = details ? details.filter(detail => detail.type === 'note') : null;
   $: list = details ? details.filter(detail => detail.type === 'olist' || detail.type === 'ulist') : null;
+  $: inConformanceTarget = $evaluation.meta.conformanceTarget.value.length >= level.substring(6).length;
 </script>
 
 <div id={normalisedCriterionId} class="criterion">
-  <h3>
-    {num}: {handle} <em>{level}</em>
-    <a href={linkToImplementing} class="criterion__ref" target="_blank">Implementing {num}</a>
-  </h3>
-  <p>{text}</p>
-  {#if list}<SuccessCriterionDetails type="list" details={list} />{/if}
-  {#if notes && notes.length > 0}<SuccessCriterionDetails type="notes" details={notes} />{/if}
-  <div class="criterion__answers">
-    <EvaluationResultSelector {id} {num} />
-    <EvaluationObservation {id} {num} />
-  </div>
+  {#if inConformanceTarget || level === "Level A, AA, AAA"}
+    <SuccessCriterionHeader {num} {handle} {level} />
+    <p>{text}</p>
+    {#if list}<SuccessCriterionDetails type="list" details={list} />{/if}
+    {#if notes && notes.length > 0}<SuccessCriterionDetails type="notes" details={notes} />{/if}
+    <div class="criterion__answers">
+      <EvaluationResultSelector {id} {num} />
+      <EvaluationObservation {id} {num} />
+    </div>
+  {:else}
+    <details>
+      <summary>
+        <SuccessCriterionHeader {num} {handle} {level} />
+      </summary>
+      <p>{text}</p>
+      {#if list}<SuccessCriterionDetails type="list" details={list} />{/if}
+      {#if notes && notes.length > 0}<SuccessCriterionDetails type="notes" details={notes} />{/if}
+      <div class="criterion__answers">
+        <EvaluationResultSelector {id} {num} />
+        <EvaluationObservation {id} {num} />
+      </div>
+    </details>
+  {/if}
 </div>
 
 <style>
@@ -44,33 +58,6 @@
   box-shadow: 1px 1px 4px -4px
     #000;
   padding: 1em;
-}
-.criterion h3 {
-  margin-top: 0;
-  font-weight: normal;
-}
-.criterion h3 em {
-  font-size: smaller;
-  font-style: normal;
-  margin: 0 2em 0 .5em;
-}
-.criterion ol li {
-  list-style: lower-alpha;
-}
-.criterion__ref {
-  padding: .25em 1em;
-  border-radius: 1em;
-  margin-left: .75em;
-  background-color: var(--cloudy-subtle);
-  border: 1px solid var(--cloudy-subtle);
-  font-size: 70%;
-  color: inherit;
-  text-decoration: none;
-  white-space: nowrap;
-}
-.criterion__ref:hover {
-  background-color: transparent;
-  border-color: var(--ocean);
 }
 .criterion__answers {
   display: flex;
@@ -104,5 +91,4 @@
     flex-direction: row;
   }
 }
-
 </style>

--- a/src/components/SuccessCriterionHeader.svelte
+++ b/src/components/SuccessCriterionHeader.svelte
@@ -1,0 +1,30 @@
+<script>
+  import LinkToSC from './LinkToSC.svelte';
+  import { normaliseCriterionId } from '../utils/normaliseCriterionId';
+
+  export let num, handle, level, linkToImplementing;
+
+  $: normalisedCriterionId = normaliseCriterionId(num);
+  $: linkToImplementing = `https://www.w3.org/WAI/AU/2012/WD-IMPLEMENTING-ATAG20-20121011/#sc_${normalisedCriterionId}`;
+</script>
+
+<h3>
+  {num}: {handle} <em>{level}</em>
+  <LinkToSC href={linkToImplementing}>Implementing {num}</LinkToSC>
+</h3>
+
+<style>
+h3 {
+  margin-top: 0;
+  margin-bottom: 0;
+  font-weight: normal;
+}
+:global([open] h3) {
+  margin-bottom: 1em;
+}
+h3 em {
+  font-size: smaller;
+  font-style: normal;
+  margin: 0 2em 0 .5em;
+}
+</style>

--- a/src/data/atag.js
+++ b/src/data/atag.js
@@ -20,7 +20,7 @@ const atag = [
             handle: "Web-Based Accessible (WCAG)",
             text:
               "If the authoring tool contains web-based user interfaces, then those web-based user interfaces meet the WCAG 2.0 success criteria.",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
           },
         ],
       },
@@ -37,7 +37,7 @@ const atag = [
             handle: "Accessibility Guidelines",
             text:
               "If the authoring tool contains non-web-based user interfaces, then those non-web-based user interfaces follow user interface accessibility guidelines for the platform.",
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "note",
@@ -53,7 +53,7 @@ const atag = [
             handle: "Platform Accessibility Services",
             text:
               "If the authoring tool contains non-web-based user interfaces, then those non-web-based user interfaces expose accessibility information through platform accessibility services.",
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "note",
@@ -87,7 +87,7 @@ const atag = [
             handle: "Text Alternatives for Rendered Non-Text Content",
             text:
               "If an editing-view renders non-text content, then any programmatically associated text alternatives for the non-text content can be programmatically determined.",
-            level: "Level A",
+            level: "A",
           },
           {
             id: "alts-for-time-based",
@@ -95,7 +95,7 @@ const atag = [
             handle: "Alternatives for Rendered Time-Based Media",
             text:
               "If an editing-view renders time-based media, then at least one of the following is true:",
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "olist",
@@ -130,7 +130,7 @@ const atag = [
             handle: "Editing-View Status Indicators",
             text:
               "If an editing-view adds status indicators to the content being edited, then the information being conveyed by the status indicators can be programmatically determined.",
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "note",
@@ -146,7 +146,7 @@ const atag = [
             handle: "Access to Rendered Text Properties",
             text:
               "If an editing-view renders any text formatting properties that authors can also edit using the editing-view, then the properties can be programmatically determined.",
-            level: "Level AA",
+            level: "AA",
           },
         ],
       },
@@ -172,7 +172,7 @@ const atag = [
             handle: "Keyboard Access (Minimum)",
             text:
               "All functionality of the authoring tool is operable through a keyboard interface without requiring specific timings for individual keystrokes, except where the underlying function requires input that depends on the path of the user's movement and not just the endpoints.",
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "note",
@@ -200,7 +200,7 @@ const atag = [
             handle: "No Keyboard Traps",
             text:
               "If keyboard focus can be moved to a component using a keyboard interface, then focus can be moved away from that component using only a keyboard interface. If it requires more than unmodified arrow or tab keys or other standard exit methods, authors are advised of the method for moving focus away.",
-            level: "Level A",
+            level: "A",
           },
           {
             id: "efficient-keyboard-access",
@@ -208,7 +208,7 @@ const atag = [
             handle: "Efficient Keyboard Access",
             text:
               "The authoring tool user interface includes mechanisms to make keyboard access more efficient than sequential keyboard access.",
-            level: "Level AA",
+            level: "AA",
           },
         ],
       },
@@ -225,7 +225,7 @@ const atag = [
             handle: "Auto-Save (minimum)",
             text:
               "The authoring tool does not include session time limits or the authoring tool can automatically save edits made before the session time limits are reached.",
-            level: "Level A",
+            level: "A",
           },
           {
             id: "timing-adjustable",
@@ -233,7 +233,7 @@ const atag = [
             handle: "Timing Adjustable",
             text:
               "The authoring tool does not include time limits or at least one of the following is true:",
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "olist",
@@ -277,7 +277,7 @@ const atag = [
             handle: "Static Input Components",
             text:
               "The authoring tool does not include moving user interface components that accept input where the movement of these components cannot be paused by authors. ",
-            level: "Level A",
+            level: "A",
           },
         ],
       },
@@ -294,7 +294,7 @@ const atag = [
             handle: "Static View Option",
             text:
               "If an editing-view can play visual time-based content, then playing is not necessarily automatic upon loading the content and playing can be paused.",
-            level: "Level A",
+            level: "A",
           },
         ],
       },
@@ -311,7 +311,7 @@ const atag = [
             handle: "Navigate by structure",
             text:
               "If editing-views expose the markup elements in the web content being edited, then the markup elements (e.g. source code, content renderings) are selectable and navigation mechanisms are provided to move the selection focus between elements.",
-            level: "Level AA",
+            level: "AA",
           },
         ],
       },
@@ -328,7 +328,7 @@ const atag = [
             handle: "Text Search",
             text:
               "If the authoring tool provides an editing-view of text-based content, then the editing-view enables text search, such that all of the following are true:",
-            level: "Level AA",
+            level: "AA",
             details: [
               {
                 type: "olist",
@@ -370,7 +370,7 @@ const atag = [
             handle: "Independence of Display",
             text:
               "If the authoring tool includes display settings for editing-views, then the authoring tool allows authors to adjust these settings without modifying the web content being edited.",
-            level: "Level A",
+            level: "A",
           },
           {
             id: "save-settings",
@@ -378,7 +378,7 @@ const atag = [
             handle: "Save Settings",
             text:
               "If the authoring tool includes display and/or control settings, then these settings can be saved between authoring sessions.",
-            level: "Level AA",
+            level: "AA",
           },
           {
             id: "apply-platform-settings",
@@ -386,7 +386,7 @@ const atag = [
             handle: "Apply Platform Settings",
             text:
               "The authoring tool respects changes in platform display and control settings, unless authors select more specific display and control settings using the authoring tool.",
-            level: "Level AA",
+            level: "AA",
           },
         ],
       },
@@ -404,7 +404,7 @@ const atag = [
             handle: "Preview (Minimum)",
             text:
               "If a preview is provided, then at least one of the following is true:",
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "olist",
@@ -415,9 +415,9 @@ const atag = [
                       "The preview renders content using a user agent that is in-market; or",
                   },
                   {
-                    handle: " UAAG (Level A)",
+                    handle: " UAAG (A)",
                     text:
-                      "The preview conforms to the User Agent Accessibility Guidelines 1.0 Level A",
+                      "The preview conforms to the User Agent Accessibility Guidelines 1.0 A",
                   },
                 ],
               },
@@ -447,7 +447,7 @@ const atag = [
             handle: "Content Changes Reversible (Minimum)",
             text:
               "All authoring actions are either reversible or the authoring tool requires author confirmation to proceed.",
-            level: "Level A",
+            level: "A",
           },
           {
             id: "settings-change-confirm",
@@ -455,7 +455,7 @@ const atag = [
             handle: "Settings Change Confirmation",
             text:
               "If the authoring tool provides mechanisms for changing authoring tool user interface settings, then those mechanisms can reverse the setting changes, or the authoring tool requires author confirmation to proceed. ",
-            level: "Level A",
+            level: "A",
           },
         ],
       },
@@ -473,7 +473,7 @@ const atag = [
             handle: "Describe Accessibility Features",
             text:
               "For each authoring tool feature that is used to meet Part A of ATAG 2.0, at least one of the following is true: (a) Described in the Documentation: Use of the feature is explained in the authoring tool's documentation; or (b) Described in the Interface: Use of the feature is explained in the authoring tool user interface; or (c) Platform Service: The feature is a service provided by an underlying platform; or (d) Not Used by Authors: The feature is not used directly by authors (e.g. passing information to a platform accessibility service).",
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "ulist",
@@ -514,7 +514,7 @@ const atag = [
             handle: "Document All Features",
             text:
               "For each authoring tool feature, at least one of the following is true:  (a) Described in the Documentation: Use of the feature is explained in the authoring tool's documentation; or (b) Described in the Interface: Use of the feature is explained in the authoring tool user interface; or (c) Platform Service: The feature is a service provided by an underlying platform; or (d) Not Used by Authors: The feature is not used directly by authors (e.g. passing information to a platform accessibility service).",
-            level: "Level AA",
+            level: "AA",
             details: [
               {
                 type: "olist",
@@ -573,7 +573,7 @@ const atag = [
             handle: "Content Auto-Generation After Authoring Sessions (WCAG)",
             text:
               "The authoring tool does not automatically generate web content after the end of an authoring session, or, authors can specify that the content be accessible web content (WCAG).",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
             details: [
               {
                 type: "note",
@@ -589,7 +589,7 @@ const atag = [
             handle: "Content Auto-Generation During Authoring Sessions (WCAG",
             text:
               " If the authoring tool provides the functionality for automatically generating web content during an authoring session, then at least one of the following is true:",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
             details: [
               {
                 type: "ulist",
@@ -645,7 +645,7 @@ const atag = [
             handle: "Restructuring and Recoding Transformations",
             text:
               "If the authoring tool provides restructuring transformations or re-coding transformations, and if equivalent mechanisms exist in the web content technology of the output, then at least one of the following is true: ",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
             details: [
               {
                 type: "olist",
@@ -692,7 +692,7 @@ const atag = [
             handle: "Copy-Paste Inside Authoring Tool (WCAG)",
             text:
               "If the authoring tool supports copy and paste of structured content, then any accessibility information (WCAG) in the copied content is preserved when the authoring tool is both the source and destination of the copy-paste and the source and destination use the same web content technology.",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
           },
           {
             id: "optimizations-preserve-accessibility",
@@ -700,7 +700,7 @@ const atag = [
             handle: "Optimizations Preserve Accessibility",
             text:
               "If the authoring tool provides optimizing web content transformations, then any accessibility information (WCAG) in the input is preserved in the output.",
-            level: "Level A",
+            level: "A",
           },
           {
             id: "text-alts-for-non-text-preserved",
@@ -708,7 +708,7 @@ const atag = [
             handle: "Text Alternatives for Non-Text Content are Preserved",
             text:
               " If the authoring tool provides web content transformations that preserve non-text content in the output, then any text alternatives for that non-text content are also preserved, if equivalent mechanisms exist in the web content technology of the output. ",
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "note",
@@ -742,7 +742,7 @@ const atag = [
             handle: "Ensure that accessible content production is possible. ",
             text:
               "The authoring tool does not place restrictions on the web content that authors can specify or those restrictions do not prevent WCAG 2.0 success criteria from being met.",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
           },
         ],
       },
@@ -758,7 +758,7 @@ const atag = [
             handle: "Accessible Option Prominence (WCAG)",
             text:
               "If authors are provided with a choice of authoring actions for achieving the same authoring outcome (e.g. styling text), then options that will result in accessible web content (WCAG) are at least as prominent as options that will not.",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
           },
           {
             id: "setting-accessibility-props",
@@ -766,7 +766,7 @@ const atag = [
             handle: "Setting Accessibility Properties (WCAG)",
             text:
               "If the authoring tool provides mechanisms to set web content properties (e.g. attribute values), then mechanisms are also provided to set web content properties related to accessibility information (WCAG).",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
           },
         ],
       },
@@ -783,7 +783,7 @@ const atag = [
             handle: "Alternative Content is Editable (WCAG)",
             text:
               "If the authoring tool provides functionality for adding non-text content, then authors are able to modify programmatically associated text alternatives for non-text content.",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
           },
           {
             id: "automatic-repair-of-text-alts",
@@ -791,7 +791,7 @@ const atag = [
             handle: "Automating Repair of Text Alternatives",
             text:
               'The authoring tool does not attempt to repair text alternatives for non-text content or the following are all true: (a) No Generic or Irrelevant Strings: Generic strings (e.g. "image") and irrelevant strings (e.g. the file handle, file format) are not used as text alternatives; and (b) In-Session Repairs: If the repair attempt occurs during an authoring session, authors have the opportunity to accept, modify, or reject the repair attempt prior to insertion of the text alternative into the content; and (c) Out-of-Session Repairs: If the repair attempt occurs after an authoring session has ended, the repaired text alternatives are indicated during subsequent authoring sessions (if any) and authors have the opportunity to accept, modify, or reject the repair strings prior to insertion in the content.',
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "olist",
@@ -830,7 +830,7 @@ const atag = [
             handle: "Accessible Template Options (WCAG)",
             text:
               "If the authoring tool provides templates, then there are accessible template (WCAG) options for a range of template uses.",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
           },
           {
             id: "identify-template-accessibility",
@@ -838,7 +838,7 @@ const atag = [
             handle: "Identify Template Accessibility",
             text:
               "If the authoring tool includes a template selection mechanism and provides any non-accessible template (WCAG) options, then the template selection mechanism can display distinctions between the accessible and non-accessible options.",
-            level: "Level AA",
+            level: "AA",
             details: [
               {
                 type: "note",
@@ -854,7 +854,7 @@ const atag = [
             text:
               "If the authoring tool includes a template selection mechanism and allows authors to create new non-accessible templates (WCAG), then authors can enable the template selection mechanism to display distinctions between accessible and non-accessible templates that they create.",
             handle: "Author-Created Templates",
-            level: "Level AA",
+            level: "AA",
             details: [
               {
                 type: "note",
@@ -878,16 +878,16 @@ const atag = [
             num: "B.2.5.1",
             handle: "Accessible Pre-Authored Content Options",
             text:
-              "If the authoring tool provides pre-authored content, then a range of accessible pre-authored content (to WCAG Level AA) options are provided.",
-            level: "Level AA",
+              "If the authoring tool provides pre-authored content, then a range of accessible pre-authored content (to WCAG AA) options are provided.",
+            level: "AA",
           },
           {
             id: "identify-pre-authored-content-accessibility",
             num: "B.2.5.2",
             handle: "Identify Pre-Authored Content Accessibility",
             text:
-              "If the authoring tool includes a pre-authored content selection mechanism and provides any non-accessible pre-authored content (WCAG Level AA) options, then the selection mechanism can display distinctions between the accessible and non-accessible options.",
-            level: "Level AA",
+              "If the authoring tool includes a pre-authored content selection mechanism and provides any non-accessible pre-authored content (WCAG AA) options, then the selection mechanism can display distinctions between the accessible and non-accessible options.",
+            level: "AA",
             details: [
               {
                 type: "note",
@@ -921,7 +921,7 @@ const atag = [
             handle: "Checking Assistance (WCAG)",
             text:
               "If the authoring tool provides authors with the ability to add or modify web content in such a way that a WCAG 2.0 success criterion can be violated, then accessibility checking for that success criterion is provided (e.g. an HTML authoring tool that inserts images should check for alternative text; a video authoring tool with the ability to edit text tracks should check for captions).",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
             details: [
               {
                 type: "note",
@@ -937,7 +937,7 @@ const atag = [
             handle: "Help Authors Decide",
             text:
               "If the authoring tool provides accessibility checking that relies on authors to decide whether potential web content accessibility problems (WCAG) are correctly identified (i.e. manual checking and semi-automated checking), then the accessibility checking process provides instructions that describe how to decide.",
-            level: "Level A",
+            level: "A",
           },
           {
             id: "help-authors-locate",
@@ -945,7 +945,7 @@ const atag = [
             handle: "Help Authors Locate",
             text:
               "If the authoring tool provides checks that require authors to decide whether a potential web content accessibility problem (WCAG) is correctly identified (i.e. manual checking and semi-automated checking), then the relevant content is identified to the authors.",
-            level: "Level A",
+            level: "A",
             details: [
               {
                 type: "note",
@@ -961,7 +961,7 @@ const atag = [
             handle: "Status Report",
             text:
               "If the authoring tool provides checks, then authors can receive an accessibility status report based on the results of the accessibility checks.",
-            level: "Level AA",
+            level: "AA",
             details: [
               {
                 type: "note",
@@ -977,7 +977,7 @@ const atag = [
             handle: "Programmatic Association of Results",
             text:
               "If the authoring tool provides checks, then the authoring tool can programmatically associate accessibility checking results with the web content that was checked.",
-            level: "Level AA",
+            level: "AA",
           },
         ],
       },
@@ -994,7 +994,7 @@ const atag = [
             handle: "Repair Assistance (WCAG",
             text:
               "If checking (see Success Criterion B.3.1.1) can detect that a WCAG 2.0 success criterion is not met, then repair suggestion(s) are provided:",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
             details: [
               {
                 type: "note",
@@ -1028,7 +1028,7 @@ const atag = [
             handle: "Features Active by Default",
             text:
               "All accessible content support features are turned on by default. ",
-            level: "Level A",
+            level: "A",
           },
           {
             id: "option-to-reactivate-features",
@@ -1036,7 +1036,7 @@ const atag = [
             handle: "Option to Reactivate Features",
             text:
               "The authoring tool does not include the option to turn off its accessible content support features or features which have been turned off can be turned back on.",
-            level: "Level A",
+            level: "A",
           },
           {
             id: "feature-deactivation-warning",
@@ -1044,7 +1044,7 @@ const atag = [
             handle: "Feature Deactivation Warning",
             text:
               "The authoring tool does not include the option to turn off its accessible content support features or, if these features can be turned off, authors are informed that this may increase the risk of content accessibility problems (WCAG).",
-            level: "Level AA",
+            level: "AA",
           },
           {
             id: "feature-prominence",
@@ -1052,7 +1052,7 @@ const atag = [
             handle: "Feature Prominence",
             text:
               "All accessible content support features are at least as prominent as features related to either invalid markup, syntax errors, spelling errors or grammar errors.",
-            level: "Level AA",
+            level: "AA",
           },
         ],
       },
@@ -1069,7 +1069,7 @@ const atag = [
             handle: "Model Practice (WCAG)",
             text:
               "A range of examples in the documentation (e.g. markup, screen shots of WYSIWYG editing-views) demonstrate accessible authoring practices (WCAG).",
-            level: "Level A, AA, AAA",
+            level: "A, AA, AAA",
           },
           {
             id: "feature-instructions",
@@ -1077,12 +1077,11 @@ const atag = [
             handle: "Feature Instructions",
             text:
               "Instructions for using any accessible content support features appear in the documentation.",
-            level: "Level A",
+            level: "A",
           },
         ],
       },
     ],
   },
 ];
-
 export default atag;

--- a/src/data/atag.js
+++ b/src/data/atag.js
@@ -210,6 +210,30 @@ const atag = [
               "The authoring tool user interface includes mechanisms to make keyboard access more efficient than sequential keyboard access.",
             level: "AA",
           },
+          {
+            id: "keyboard-access-enhanced",
+            num: "A.3.1.4",
+            handle: "Keyboard Access (Enhanced)",
+            text:
+              "All functionality of the authoring tool is operable through a keyboard interface without requiring specific timings for individual keystrokes.",
+            level: "AAA",
+          },
+          {
+            id: "customise-keyboard-access",
+            num: "A.3.1.5",
+            handle: "Customize Keyboard Access",
+            text:
+              "If the authoring tool includes keyboard commands, then those keyboard commands can be customized.",
+            level: "AAA",
+          },
+          {
+            id: "present-keyboard-commands",
+            num: "A.3.1.6",
+            handle: "Present Keyboard Commands",
+            text:
+              "If the authoring tool includes keyboard commands, then the authoring tool provides a way for authors to determine the keyboard commands associated with authoring tool user interface components.",
+            level: "AAA",
+          },
         ],
       },
       {
@@ -279,6 +303,14 @@ const atag = [
               "The authoring tool does not include moving user interface components that accept input where the movement of these components cannot be paused by authors. ",
             level: "A",
           },
+          {
+            id: "content-edits-saved",
+            num: "A.3.2.4",
+            handle: "Content Edits Saved (Extended)",
+            text:
+              "The authoring tool can be set to automatically save web content edits made using the authoring tool.",
+            level: "AAA",
+          },
         ],
       },
       {
@@ -312,6 +344,22 @@ const atag = [
             text:
               "If editing-views expose the markup elements in the web content being edited, then the markup elements (e.g. source code, content renderings) are selectable and navigation mechanisms are provided to move the selection focus between elements.",
             level: "AA",
+          },
+          {
+            id: "navigate-by-relationships",
+            num: "A.3.4.2",
+            handle: "Navigate by Programmatic Relationships",
+            text:
+              " If editing-views allow editing of programmatic relationships within web content, then mechanisms are provided that support navigation between the related content.",
+            level: "AAA",
+            details: [
+              {
+                type: "note",
+                handle: "Note",
+                text:
+                  "Depending on the web content technology and the nature of the authoring tool, relationships may include, but are not limited to, element nesting, headings, labeling, programmatic definitions, and ID relationships.",
+              },
+            ],
           },
         ],
       },
@@ -423,6 +471,14 @@ const atag = [
               },
             ],
           },
+          {
+            id: "preview-enhanced",
+            num: "A.3.7.2",
+            handle: "Preview (Enhanced)",
+            text:
+              "If a preview is provided, then authors can specify which user agent performs the preview.",
+            level: "AAA",
+          },
         ],
       },
     ],
@@ -456,6 +512,22 @@ const atag = [
             text:
               "If the authoring tool provides mechanisms for changing authoring tool user interface settings, then those mechanisms can reverse the setting changes, or the authoring tool requires author confirmation to proceed. ",
             level: "A",
+          },
+          {
+            id: "content-changes-reversible-enhanced",
+            num: "A.4.1.3",
+            handle: "Content Changes Reversible (Enhanced)",
+            text:
+              "Authors can sequentially reverse a series of reversible authoring actions. (Level AAA)",
+            level: "AAA",
+            details: [
+              {
+                type: "note",
+                handle: "Note",
+                text:
+                  "It is acceptable to clear the authoring action history at the end of authoring sessions.",
+              },
+            ],
           },
         ],
       },
@@ -815,6 +887,31 @@ const atag = [
               },
             ],
           },
+          {
+            id: "save-for-reuse",
+            num: "B.2.3.3",
+            handle: "Save for Reuse",
+            text:
+              "If the authoring tool provides the functionality for adding non-text content, when authors enter programmatically associated text alternatives for non-text content, then both of the following are true:",
+            level: "AAA",
+            details: [
+              {
+                type: "olist",
+                items: [
+                  {
+                    handle: "Save and Suggest",
+                    text:
+                      "The text alternatives are automatically saved and suggested by the authoring tool, if the same non-text content is reused; and",
+                  },
+                  {
+                    handle: "Edit Option",
+                    text:
+                      "The author has the option to edit or delete the saved text alternatives.",
+                  },
+                ],
+              },
+            ],
+          },
         ],
       },
       {
@@ -863,6 +960,14 @@ const atag = [
                   "The distinction can involve providing information for the accessible templates (WCAG), the non-accessible templates or both.",
               },
             ],
+          },
+          {
+            id: "accessible-template-options-enhanced",
+            num: "B.2.4.4",
+            text:
+              "If the authoring tool provides templates, then all of the templates are accessible template (to WCAG Level AA).",
+            handle: "Accessible Template Options (Enhanced)",
+            level: "AAA",
           },
         ],
       },
@@ -1078,6 +1183,22 @@ const atag = [
             text:
               "Instructions for using any accessible content support features appear in the documentation.",
             level: "A",
+          },
+          {
+            id: "tutorial",
+            num: "B.4.2.3",
+            handle: "Tutorial",
+            text:
+              "The authoring tool provides a tutorial for an accessible authoring process that is specific to that authoring tool.",
+            level: "AAA",
+          },
+          {
+            id: "instruction-index",
+            num: "B.4.2.4",
+            handle: "Instruction Index",
+            text:
+              "The authoring tool documentation contains an index to the instructions for using any accessible content support features.",
+            level: "AAA",
           },
         ],
       },

--- a/src/routes/Report.svelte
+++ b/src/routes/Report.svelte
@@ -182,6 +182,9 @@
     font-weight: bold;
     margin-left: 0;
   }
+  table {
+    width: 100%;
+  }
   tr:target {
     outline: 2px solid var(--gold);
   }

--- a/src/routes/Report.svelte
+++ b/src/routes/Report.svelte
@@ -138,9 +138,9 @@
 	</thead>
 	<tbody>
 	{#each Object.values($evaluation.evaluationData) as result}
-  {#if ($evaluation.meta.conformanceTarget.value.length < result.level.length) && result.level !== 'A, AA, AAA' }
+  {#if ($evaluation.meta.conformanceTarget.value.length < result.level.length) && result.level !== 'A, AA, AAA' && result.evaluated !== true}
   <tr>
-    <td colspan="4">{$evaluation.meta.conformanceTarget.value} -- {result.level} -- {result.num} was not in scope for this report</td>
+    <td colspan="4">{result.num} was not in scope for this report</td>
   </tr>
   {:else}
 	<tr id={`criterion-${result.num.replace(/\./g, '').toLowerCase()}`}>

--- a/src/routes/Report.svelte
+++ b/src/routes/Report.svelte
@@ -67,6 +67,12 @@
   {:else}
   <dd>Not provided</dd>
   {/if}
+  <dt>Conformance Target</dt>
+  {#if $evaluation["meta"]["conformanceTarget"] && $evaluation["meta"]["conformanceTarget"]["value"]}
+  <dd>{$evaluation["meta"]["conformanceTarget"]["value"]}</dd>
+  {:else}
+  <dd>Not provided</dd>
+  {/if}
   <dt>Evaluator</dt>
   {#if $evaluation["meta"]["evaluatorName"] && $evaluation["meta"]["evaluatorName"]["value"]}
   <dd>{$evaluation["meta"]["evaluatorName"]["value"]}</dd>

--- a/src/routes/Report.svelte
+++ b/src/routes/Report.svelte
@@ -169,10 +169,9 @@
     :global(.report-header a) {
       margin-left: auto;
     }
-  dl {
-    column-count: 2;
-  }
   dt {
+    grid-column: 1 / 2;
+    margin-top: 0;
     font-weight: normal;
   }
   dt:after {
@@ -181,6 +180,17 @@
   dd {
     font-weight: bold;
     margin-left: 0;
+    margin-bottom: 1em;
+  }
+  @media (min-width: 40em) {
+    dl {
+      display: grid;
+      grid-template-columns: auto 2fr;
+      gap: .5em 3em;
+    }
+    dd {
+      margin-bottom: 0;
+    }
   }
   table {
     width: 100%;

--- a/src/routes/Report.svelte
+++ b/src/routes/Report.svelte
@@ -69,7 +69,7 @@
   {/if}
   <dt>Conformance Target</dt>
   {#if $evaluation["meta"]["conformanceTarget"] && $evaluation["meta"]["conformanceTarget"]["value"]}
-  <dd>{$evaluation["meta"]["conformanceTarget"]["value"]}</dd>
+  <dd>Level {$evaluation["meta"]["conformanceTarget"]["value"]}</dd>
   {:else}
   <dd>Not provided</dd>
   {/if}
@@ -138,6 +138,11 @@
 	</thead>
 	<tbody>
 	{#each Object.values($evaluation.evaluationData) as result}
+  {#if ($evaluation.meta.conformanceTarget.value.length < result.level.length) && result.level !== 'A, AA, AAA' }
+  <tr>
+    <td colspan="4">{$evaluation.meta.conformanceTarget.value} -- {result.level} -- {result.num} was not in scope for this report</td>
+  </tr>
+  {:else}
 	<tr id={`criterion-${result.num.replace(/\./g, '').toLowerCase()}`}>
 		<td class="results-label-sc">{result.num}: {result.handle}</td>
 		<td><span class="results-label-mobile">Result: </span>{result.result ? result.result : 'No result'}</td>
@@ -153,6 +158,7 @@
       </Link>
     </td>
 	</tr>
+  {/if}
 	{/each}
 	</tbody>
 </table>

--- a/src/routes/Start.svelte
+++ b/src/routes/Start.svelte
@@ -52,6 +52,17 @@
 </div>
 {/if}
 
+{#if $evaluation["meta"]["conformanceTarget"]}
+<div class="field">
+  <label for="evaluation-meta-conformance-target">Conformance Target</label>
+  <select name="evaluation-meta-conformance-target" id="evaluation-meta-conformance-target" bind:value={$evaluation["meta"]["conformanceTarget"]["value"]} on:change={() => { evaluation.updateCache($evaluation);}}>
+    <option value="A">Level A</option>
+    <option value="AA">Level AA</option>
+    <option value="AAA">Level AAA</option>
+  </select>
+</div>
+{/if}
+
 <Pager label="Previous/Next Principle">
   <PagerLink to="/" direction="previous">Overview</PagerLink>
   <PagerLink to="/principle/1" direction="next">A.1</PagerLink>

--- a/src/utils/createCleanEvaluation.js
+++ b/src/utils/createCleanEvaluation.js
@@ -39,6 +39,10 @@ export function createCleanEvaluation() {
       id: "evaluatorOrg",
       value: null,
     },
+    conformanceTarget: {
+      id: "conformanceTarget",
+      value: "AA",
+    },
     createdWith: {
       id: "createdWith",
       value: packageJson.version,

--- a/src/utils/createCleanEvaluation.js
+++ b/src/utils/createCleanEvaluation.js
@@ -17,6 +17,7 @@ export function createCleanEvaluation() {
           result: null,
           observations: null,
           evaluated: false,
+          level: successcriterion.level,
         };
       }
     }


### PR DESCRIPTION
This adds setting for conformance target, which impacts how SCs are shown (in the regular way if within conformance target, in expand/collapse if not). 

It also: 

* adds all AAA criteria from ATAG to the tool
* will reflect in real time how many criteria there are in total