### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,23 +11,23 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         persist-credentials: false
     - name: Use Node.js '12.x'
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v4
       with:
         node-version: '12.x'
     - run: npm install
     - run: export NODE_ENV=ghpages && npm run build
     - run: cd public && ln -s index.html 404.html # symlink for GH pages fallback
     - name: Deploy 🚀
-      uses: JamesIves/github-pages-deploy-action@4.1.3
+      uses: peaceiris/actions-gh-pages@v4
       with:
-        BRANCH: gh-pages
-        FOLDER: public
-        ssh-key: ${{ secrets.DEPLOY_KEY }}
-          
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: public


### PR DESCRIPTION
This PR:
* Updates GitHub Actions dependencies
* Uses `peaceiris/actions-gh-pages` to deploy to `gh-pages`
* Uses the `GITHUB_TOKEN` instead of a secret `DEPLOY_KEY`