### PR TITLE
Upgrade actions/checkout and actions/setup-node to v6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
     - name: Checkout 🛎️
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Use Node.js '12.x'
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '12.x'
     - run: npm install


### PR DESCRIPTION
This resolves warnings about actions that rely on Node v20.

[Example successful run on fork](https://github.com/kfranqueiro/wai-atag-report-tool/actions/runs/27633118654)